### PR TITLE
FEATURE: Add check for duplicate calls and add params for timers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a quick reference, for the full documentation go to [API for clubislive]
 ## notes
 
 ### debug
- * Requst Timers
+ * Request Timers
    * start: `localStorage.setItem('api-log-times',1)` in the browser console to activate timers.
    * stop: `localStorage.removeItem('api-log-times')` in the browser console to deactivate timers.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ This is a quick reference, for the full documentation go to [API for clubislive]
 
 ## notes
 
+### debug
+ * Requst Timers
+   * start: `localStorage.setItem('api-log-times',1)` in the browser console to activate timers.
+   * stop: `localStorage.removeItem('api-log-times')` in the browser console to deactivate timers.
+
 ### properties
 These can be set during initialization in an options object, or afterwards
 


### PR DESCRIPTION
USE: localStorage.setItem('api-log-times') in the browser console to activate timers.

USE: localStorage.removeItem('api-log-times') in the browser console to deactivate timers.